### PR TITLE
Slab allocator

### DIFF
--- a/memory allocators/Slab.c
+++ b/memory allocators/Slab.c
@@ -54,5 +54,24 @@ void* slab_alloc(void* data, Frame* frame) {
 
 	memcpy(slab->mem, data, frame->slab_size);
 	return slab->mem;
+}
 
+
+
+void slab_free(void* data, Frame* frame) {
+	if(frame == 0 || data == NULL) { return NULL;  }
+
+
+	Slab* new_slab = slab_create(data);
+	new_slab->next = frame->available;
+	frame->available = new_slab;
+}
+
+void frame_free(Frame* frame) {
+	if(frame == NULL){ return; }
+
+	free(frame->start);
+
+	frame->start = NULL;
+	frame->available;
 }

--- a/memory allocators/Slab.c
+++ b/memory allocators/Slab.c
@@ -1,6 +1,6 @@
 #include "Slab.h"
 
-
+// honestly this just exists in case I need to change in later
 Slab* slab_create(void* memory) {
 	return &((Slab) {memory, NULL});
 }
@@ -11,6 +11,7 @@ Slab* slab_list_create(void* memory, size_t slab_size, uint32_t slab_count) {
 	Slab* result = current;
 	for (size_t i = 0; i < slab_count; i++) {
 		Slab* new_slab = slab_create(((char*)current->mem) + slab_size);
+
 		current->next = new_slab;
 		current = new_slab;
 	}
@@ -30,4 +31,28 @@ Frame* frame_create(const size_t slab_size, const uint32_t slab_count) {
 	Slab* slab_list = slab_list_create(chunk, slab_size, slab_count);
 
 	return &(Frame) {chunk, slab_size, slab_count, slab_list};
+}
+
+
+
+void* slab_alloc_raw(Frame* frame) {
+	if(frame == 0 || frame->available == NULL) { return NULL;  }
+
+	Slab* slab = frame->available;
+	frame->available = slab->next;
+	slab->next = NULL;
+	return slab->mem;
+}
+
+
+void* slab_alloc(void* data, Frame* frame) {
+	if(frame == 0 || frame->available == NULL || data == NULL) { return NULL;  }
+
+	Slab* slab = frame->available;
+	frame->available = slab->next;
+	slab->next = NULL;
+
+	memcpy(slab->mem, data, frame->slab_size);
+	return slab->mem;
+
 }

--- a/memory allocators/Slab.c
+++ b/memory allocators/Slab.c
@@ -1,0 +1,33 @@
+#include "Slab.h"
+
+
+Slab* slab_create(void* memory) {
+	return &((Slab) {memory, NULL});
+}
+
+Slab* slab_list_create(void* memory, size_t slab_size, uint32_t slab_count) {
+
+	Slab* current = slab_create(memory);
+	Slab* result = current;
+	for (size_t i = 0; i < slab_count; i++) {
+		Slab* new_slab = slab_create(((char*)current->mem) + slab_size);
+		current->next = new_slab;
+		current = new_slab;
+	}
+
+	return result;
+}
+
+// creates a frame of slabs
+Frame* frame_create(const size_t slab_size, const uint32_t slab_count) {
+	if (slab_size == 0 || slab_count == 0) {
+		return NULL;
+	}
+
+	void* chunk = malloc(slab_size * slab_count);
+	if(chunk == NULL) { return NULL; }
+
+	Slab* slab_list = slab_list_create(chunk, slab_size, slab_count);
+
+	return &(Frame) {chunk, slab_size, slab_count, slab_list};
+}

--- a/memory allocators/Slab.c
+++ b/memory allocators/Slab.c
@@ -33,9 +33,19 @@ Frame frame_create(const size_t slab_size, const uint32_t slab_count) {
 	return (Frame) {chunk, slab_size, slab_count, slab_list};
 }*/
 
-Frame frame_create(const size_t slab_size, const uint32_t slab_count) {
-	if (slab_size < sizeof(void*) || slab_count == 0) {
+Frame frame_create(size_t slab_size, const uint32_t slab_count) {
+
+	// so at the moment, this will not work for storing types that are smaller than 
+	// a pointer (such as a float), since a pointer to the next available slab is stored IN an 
+	// available slab. I could either just have slabs have a minimum size equal to pointer size,
+	// or maybe store an int offset in each available slab
+	// for now just have a default slab size be equal to the size of a pointer
+	if (slab_size == 0|| slab_count == 0) {
 		return FRAME_ERROR;
+	}
+
+	if (slab_size < sizeof(void*)) {
+		slab_size = sizeof(void*);
 	}
 
 	void* chunk = malloc(slab_size * slab_count);

--- a/memory allocators/Slab.c
+++ b/memory allocators/Slab.c
@@ -1,11 +1,11 @@
 #include "Slab.h"
 
-// honestly this just exists in case I need to change in later
-Slab* slab_create(void* memory) {
+// Honestly this just exists in case I need to change in later
+/* static inline Slab* slab_create(void* memory) {
 	return &((Slab) {memory, NULL});
 }
 
-Slab* slab_list_create(void* memory, size_t slab_size, uint32_t slab_count) {
+static Slab* slab_list_create(void* memory, size_t slab_size, uint32_t slab_count) {
 
 	Slab* current = slab_create(memory);
 	Slab* result = current;
@@ -31,9 +31,32 @@ Frame frame_create(const size_t slab_size, const uint32_t slab_count) {
 	Slab* slab_list = slab_list_create(chunk, slab_size, slab_count);
 
 	return (Frame) {chunk, slab_size, slab_count, slab_list};
+}*/
+
+Frame frame_create(const size_t slab_size, const uint32_t slab_count) {
+	if (slab_size < sizeof(void*) || slab_count == 0) {
+		return FRAME_ERROR;
+	}
+
+	void* chunk = malloc(slab_size * slab_count);
+	if(chunk == NULL){ return FRAME_ERROR; }
+
+	// set data in each slab to contain a pointer to the next available slab location
+	void* head = chunk;
+	for (size_t i = 0; i < slab_count * slab_size - 1; i += slab_size) {
+		head = (char*)head + i;
+		*(void**)head = (char*)head + slab_size;
+	}
+	*(void**)head = NULL;
+
+	return (Frame){chunk, chunk, slab_size, slab_count};
+
+	/*return (Frame) {
+		.start = chunk,
+		.available = chunk, 
+		.slab_size = slab_size,
+		.slab_count = slab_count}; */
 }
-
-
 
 void* slab_alloc_raw(Frame* frame) {
 	if(frame == 0 || frame->available == NULL) {
@@ -41,10 +64,15 @@ void* slab_alloc_raw(Frame* frame) {
 		return NULL; 
 	}
 
-	Slab* slab = frame->available;
+	/*Slab* slab = frame->available;
 	frame->available = slab->next;
 	slab->next = NULL;
-	return slab->mem;
+	return slab->mem;*/
+
+	void* slab = frame->available;
+	frame->available = *(void**)frame->available;
+	
+	return slab;
 }
 
 
@@ -54,12 +82,29 @@ void* slab_alloc(void* data, Frame* frame) {
 		return NULL;
 	}
 
-	Slab* slab = frame->available;
+	/*Slab* slab = frame->available;
 	frame->available = slab->next;
-	slab->next = NULL;
+	slab->next = NULL;*/
 
-	memcpy(slab->mem, data, frame->slab_size);
-	return slab->mem;
+	void* slab = frame->available;
+	frame->available = *(void**)frame->available;
+
+	memcpy(slab, data, frame->slab_size);
+	return slab;
+}
+
+
+uint32_t count_available_slabs(Frame* frame) {
+	uint32_t count = 0;
+	void* available_slab = frame->available;
+	
+	while (available_slab != NULL) {
+		count++;
+		//available_slab = available_slab->next;
+		available_slab = *(void**)available_slab;
+	}
+	
+	return count;
 }
 
 
@@ -70,10 +115,13 @@ void slab_free(void* location, Frame* frame) {
 	
 	// zeroing out the old memory COULD be optional.
 	// less safe of course, but saves time (though memset is pretty fast)
-	memset(location, 0, frame->slab_size);
+	/*memset(location, 0, frame->slab_size);
 	Slab* new_slab = slab_create(location);
 	new_slab->next = frame->available;
-	frame->available = new_slab;
+	frame->available = new_slab;*/
+
+	*(void**)location = frame->available;
+	frame->available = location;
 }
 
 void frame_free(Frame* frame) {

--- a/memory allocators/Slab.h
+++ b/memory allocators/Slab.h
@@ -40,17 +40,23 @@ typedef struct {
 typedef struct {
 	void* start;					// pointer to the full chunk of memory
 	void* available;				// pointer to an available chunk 
-	const size_t slab_size;			// size of each slab in the frame
-	const uint32_t slab_count;		// number of slabs in the frame
+	size_t slab_size;			// size of each slab in the frame
+	uint32_t slab_count;		// number of slabs in the frame
 	// Slab* available;
 }Frame;
 
 #define FRAME_ERROR (Frame) { NULL, 0, 0, NULL };
 
+typedef int SLAB_RESULT;
+#define SLAB_FAILURE 0
+#define SLAB_SUCCESS 1
+#define SLAB_INVALID_INPUT 2
+
 //static Slab* slab_create(void* memory);
 //static Slab* slab_list_create(void* memory, size_t slab_size, uint32_t slab_count);
 
-Frame frame_create(const size_t slab_size, const uint32_t slab_count);
+Frame frame_create2(const size_t slab_size, const uint32_t slab_count);
+SLAB_RESULT frame_create(const size_t slab_size, const uint32_t slab_count, Frame* frame);
 
 void* slab_alloc_raw(Frame* frame);
 void* slab_alloc(void* data, Frame* frame);

--- a/memory allocators/Slab.h
+++ b/memory allocators/Slab.h
@@ -1,0 +1,38 @@
+#ifndef SLAB_H
+#define SLAB_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+// this is (what I think is) a slab allocator. It mallocs a large pool of memory (similar to a pool)
+// but divides it into equal-sized slabs. It maintians a linked list of unused slabs. When a slab is
+// used, it is removed from the linked list. When a slab is "freed" it is added back on to the linked list
+//
+// it may also be worth considering maintaining a linked list of memory that is currently in use, in order to 
+// handle dangling pointers upon freeing the whole frame
+
+
+typedef unsigned int uint32_t;
+
+
+// maybe include a pointer to the frame that owns the slab?
+typedef struct {
+	void* mem;
+	void* next;
+}Slab;
+
+typedef struct {
+	void* start;					// pointer to the full chunk of memory
+	const size_t slab_size;			// size of each slab in the frame
+	const uint32_t slab_count;		// number of slabs in the frame
+	Slab* available;				// pointer to an available chunk 
+}Frame;
+
+static Slab* slab_create(void* memory, size_t offset);
+static Slab* slab_list_create(void* memory, size_t slab_size, uint32_t slab_count);
+
+Frame* frame_create(const size_t slab_size, const uint32_t slab_count);
+
+#endif

--- a/memory allocators/Slab.h
+++ b/memory allocators/Slab.h
@@ -17,6 +17,7 @@
 // parameter without checking that it is the start of a slab or anything, so it could be unsafe. 
 // alternatively, do the linked list of slabs in use, so it can be found and removed from there (this is slow)
 
+
 typedef unsigned int uint32_t;
 
 
@@ -33,15 +34,17 @@ typedef struct {
 	Slab* available;				// pointer to an available chunk 
 }Frame;
 
+#define FRAME_ERROR (Frame) { NULL, 0, 0, NULL };
+
 static Slab* slab_create(void* memory);
 static Slab* slab_list_create(void* memory, size_t slab_size, uint32_t slab_count);
 
-Frame* frame_create(const size_t slab_size, const uint32_t slab_count);
+Frame frame_create(const size_t slab_size, const uint32_t slab_count);
 
 void* slab_alloc_raw(Frame* frame);
 void* slab_alloc(void* data, Frame* frame);
 
-void slab_free(void* memory, Frame* frame);
+void slab_free(void* location, Frame* frame);
 
 void frame_free(Frame* frame);
 

--- a/memory allocators/Slab.h
+++ b/memory allocators/Slab.h
@@ -12,7 +12,10 @@
 //
 // it may also be worth considering maintaining a linked list of memory that is currently in use, in order to 
 // handle dangling pointers upon freeing the whole frame
-
+//
+// maybe have slab_alloc return an actual slab instead of a pointer to memory? slab_free takes a void* as a 
+// parameter without checking that it is the start of a slab or anything, so it could be unsafe. 
+// alternatively, do the linked list of slabs in use, so it can be found and removed from there (this is slow)
 
 typedef unsigned int uint32_t;
 
@@ -37,5 +40,9 @@ Frame* frame_create(const size_t slab_size, const uint32_t slab_count);
 
 void* slab_alloc_raw(Frame* frame);
 void* slab_alloc(void* data, Frame* frame);
+
+void slab_free(void* memory, Frame* frame);
+
+void frame_free(Frame* frame);
 
 #endif

--- a/memory allocators/Slab.h
+++ b/memory allocators/Slab.h
@@ -8,41 +8,28 @@
 #include <stdint.h>
 
 // this is (what I think is) a slab allocator. It mallocs a large pool of memory (similar to a pool)
-// but divides it into equal-sized slabs. It maintians a linked list of unused slabs. When a slab is
-// used, it is removed from the linked list. When a slab is "freed" it is added back on to the linked list
-//
-// it may also be worth considering maintaining a linked list of memory that is currently in use, in order to 
-// handle dangling pointers upon freeing the whole frame
-//
-// maybe have slab_alloc return an actual slab instead of a pointer to memory? slab_free takes a void* as a 
-// parameter without checking that it is the start of a slab or anything, so it could be unsafe. 
-// alternatively, do the linked list of slabs in use, so it can be found and removed from there (this is slow)
-//
-// Instead of using a slab struct (incorrectly btw, since I keep it stack allocated which is a huge mistake) I
-// could just store a pointer to the next available location in each available slab. This only fails if you 
-// want slabs that are smaller than the size of a pointer, but I could work around that later
-// you may be able to work around small slab sizes by having each slab store an int offset that fits in each 
-// slab, but of course this limits how many slabs you can have.
-//
+// but divides it into equal-sized slabs. unused slabs make up a linked list, where each unused location
+// stores a pointer to another unused location. The last in the list points to NULL.
+// because unused slabs store pointers, the default slab size is equal to sizeof(void*) 
+// 
+// I want to figure out a way to make some functions here more safe. for example, slab_free takes a void*
+// as a parameter, and there's not much of a way to chck that the memory you submit to be free is also 
+// part of the frame you pass in as a parameter. You could even theoretically pass in a pointer to the
+// same frame for both parameters, which could be funny. The same is kind of true for slab_alloc, but 
+// I think making that safe is a bit easier, and the memory copied over is based on slab_size
+// A big issue is that this not so safe stuff is hard to track down. The allocator doesn't crash 
+// immediately, it usually happens when freeing slab_free
 
-
-//typedef unsigned int uint32_t;
-
-
-// maybe include a pointer to the frame that owns the slab?
-/*
-typedef struct {
-	void* mem;
-	struct Slab* next;
-}Slab;
-*/
+// ways to enforce passing in proper memory locations into slab_free:
+// 1) | have slab_allocate return a slab struct instead, and have slab_free take a slab pointer as a parameter
+//    | instead of a void*. This makes it less user friendly I think, since you would have to go through a slab
+//    | struct instead of just the value directly.
 
 typedef struct {
 	void* start;					// pointer to the full chunk of memory
 	void* available;				// pointer to an available chunk 
-	size_t slab_size;			// size of each slab in the frame
-	uint32_t slab_count;		// number of slabs in the frame
-	// Slab* available;
+	size_t slab_size;				// size of each slab in the frame
+	uint32_t slab_count;			// number of slabs in the frame
 }Frame;
 
 #define FRAME_ERROR (Frame) { NULL, 0, 0, NULL };
@@ -55,7 +42,6 @@ typedef int SLAB_RESULT;
 //static Slab* slab_create(void* memory);
 //static Slab* slab_list_create(void* memory, size_t slab_size, uint32_t slab_count);
 
-Frame frame_create2(const size_t slab_size, const uint32_t slab_count);
 SLAB_RESULT frame_create(const size_t slab_size, const uint32_t slab_count, Frame* frame);
 
 void* slab_alloc_raw(Frame* frame);

--- a/memory allocators/Slab.h
+++ b/memory allocators/Slab.h
@@ -30,9 +30,12 @@ typedef struct {
 	Slab* available;				// pointer to an available chunk 
 }Frame;
 
-static Slab* slab_create(void* memory, size_t offset);
+static Slab* slab_create(void* memory);
 static Slab* slab_list_create(void* memory, size_t slab_size, uint32_t slab_count);
 
 Frame* frame_create(const size_t slab_size, const uint32_t slab_count);
+
+void* slab_alloc_raw(Frame* frame);
+void* slab_alloc(void* data, Frame* frame);
 
 #endif

--- a/memory allocators/memory allocators.vcxproj
+++ b/memory allocators/memory allocators.vcxproj
@@ -20,9 +20,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Pool.h" />
+    <ClInclude Include="Slab.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Pool.c" />
+    <ClCompile Include="Slab.c" />
     <ClCompile Include="testing.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/memory allocators/memory allocators.vcxproj.filters
+++ b/memory allocators/memory allocators.vcxproj.filters
@@ -18,12 +18,18 @@
     <ClInclude Include="Pool.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Slab.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Pool.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="testing.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Slab.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/memory allocators/testing.c
+++ b/memory allocators/testing.c
@@ -43,8 +43,33 @@ void test_pool_create() {
 }
 
 void test_slab_create() {
-	Frame* frame = frame_create(sizeof(float), 4);
-	printf("test: %ld \n", frame->slab_count);
+	Frame frame = frame_create(sizeof(float), 2);
+	printf("test: %ld \n", frame.slab_count);
+
+
+	printf("\ntesting raw allocation: \n");
+	float* s_a = slab_alloc_raw(&frame);
+	*s_a = 1.0f;
+	printf("data at a: %f\n", *s_a);
+
+
+	printf("\ntesting normal allocation: \n");
+	float b = 2.0f;
+	float* s_b = slab_alloc(&b, &frame);
+	printf("data at slab b: %f\n", *s_b);
+
+	printf("\ntesting allocating beyond frame capacity: \n");
+	slab_alloc(&b, &frame);
+
+	printf("\ntesting slab_free:\n");
+	slab_free(s_a, &frame);
+	s_a = NULL;
+	printf("allocating a new slab...\n");
+	float* s_c = slab_alloc_raw(&frame);
+	*s_c = 3.0f;
+	printf("data at slab c (formerly slab a): %f\n", *s_c);
+
+	frame_free(&frame);
 }
 
 

--- a/memory allocators/testing.c
+++ b/memory allocators/testing.c
@@ -46,7 +46,10 @@ void test_slab_create() {
 
 	//Frame frame = frame_create(sizeof(float), 2);
 	Frame frame;
-	frame_create(sizeof(float), 2, &frame);
+	if (frame_create(sizeof(float), 2, &frame) != SLAB_SUCCESS) {
+		printf("failed to create a frame! check inputs\n") ;
+		exit;
+	}
 
 	printf("test: %ld \n", frame.slab_count);
 
@@ -81,18 +84,33 @@ void test_slab_create() {
 	printf("data at slab c (formerly slab a): %f\n", *s_c);
 	printf("available slabs: %d\n", count_available_slabs(&frame));
 
+	frame_free(&frame);
+}
+
+void test_weird_frame() {
+	Frame frame;
+	if (frame_create(sizeof(Frame), 5, &frame) != SLAB_SUCCESS) {
+		printf("failed to allocate a frame, check you inputs \n");
+		exit;
+	}
+
+	Frame* f1 = slab_alloc_raw(&frame);
+	//slab_free(&frame, &frame);
 
 	frame_free(&frame);
 }
 
 
 void run_tests() {
-	switch (2) {
+	switch (3) {
 	case 1:
 		test_pool_create();
 		break;
 	case 2:
 		test_slab_create();
+		break;
+	case 3:
+		test_weird_frame();
 		break;
 	default:
 		printf("no tests\n");

--- a/memory allocators/testing.c
+++ b/memory allocators/testing.c
@@ -43,7 +43,7 @@ void test_pool_create() {
 }
 
 void test_slab_create() {
-	Frame frame = frame_create(sizeof(double), 2);
+	Frame frame = frame_create(sizeof(float), 2);
 	printf("test: %ld \n", frame.slab_count);
 
 	printf("testing count_available_slabs: \n");
@@ -51,13 +51,13 @@ void test_slab_create() {
 
 	printf("\ntesting raw allocation: \n");
 	float* s_a = slab_alloc_raw(&frame);
-	*s_a = 1.0;
+	*s_a = 1.0f;
 	printf("data at a: %f\n", *s_a);
 	printf("available slabs: %d\n", count_available_slabs(&frame));
 
 
 	printf("\ntesting normal allocation: \n");
-	float b = 2.0;
+	float b = 2.0f;
 	float* s_b = slab_alloc(&b, &frame);
 	printf("data at slab b: %f\n", *s_b);
 	printf("available slabs: %d\n", count_available_slabs(&frame));

--- a/memory allocators/testing.c
+++ b/memory allocators/testing.c
@@ -43,7 +43,11 @@ void test_pool_create() {
 }
 
 void test_slab_create() {
-	Frame frame = frame_create(sizeof(float), 2);
+
+	//Frame frame = frame_create(sizeof(float), 2);
+	Frame frame;
+	frame_create(sizeof(float), 2, &frame);
+
 	printf("test: %ld \n", frame.slab_count);
 
 	printf("testing count_available_slabs: \n");

--- a/memory allocators/testing.c
+++ b/memory allocators/testing.c
@@ -1,4 +1,5 @@
 #include "Pool.h"
+#include "Slab.h"
 
 void test_pool_create() {
 	Pool pool = pool_create(sizeof(float) + sizeof(int));
@@ -41,11 +42,19 @@ void test_pool_create() {
 	pool_free(&pool);
 }
 
+void test_slab_create() {
+	Frame* frame = frame_create(sizeof(float), 4);
+	printf("test: %ld \n", frame->slab_count);
+}
+
 
 void run_tests() {
-	switch (1) {
+	switch (2) {
 	case 1:
 		test_pool_create();
+		break;
+	case 2:
+		test_slab_create();
 		break;
 	default:
 		printf("no tests\n");

--- a/memory allocators/testing.c
+++ b/memory allocators/testing.c
@@ -43,20 +43,25 @@ void test_pool_create() {
 }
 
 void test_slab_create() {
-	Frame frame = frame_create(sizeof(float), 2);
+	Frame frame = frame_create(sizeof(double), 2);
 	printf("test: %ld \n", frame.slab_count);
 
+	printf("testing count_available_slabs: \n");
+	printf("available slabs: %d\n", count_available_slabs(&frame));
 
 	printf("\ntesting raw allocation: \n");
 	float* s_a = slab_alloc_raw(&frame);
-	*s_a = 1.0f;
+	*s_a = 1.0;
 	printf("data at a: %f\n", *s_a);
+	printf("available slabs: %d\n", count_available_slabs(&frame));
 
 
 	printf("\ntesting normal allocation: \n");
-	float b = 2.0f;
+	float b = 2.0;
 	float* s_b = slab_alloc(&b, &frame);
 	printf("data at slab b: %f\n", *s_b);
+	printf("available slabs: %d\n", count_available_slabs(&frame));
+
 
 	printf("\ntesting allocating beyond frame capacity: \n");
 	slab_alloc(&b, &frame);
@@ -64,10 +69,14 @@ void test_slab_create() {
 	printf("\ntesting slab_free:\n");
 	slab_free(s_a, &frame);
 	s_a = NULL;
+	printf("available slabs: %d\n", count_available_slabs(&frame));
+
 	printf("allocating a new slab...\n");
 	float* s_c = slab_alloc_raw(&frame);
 	*s_c = 3.0f;
 	printf("data at slab c (formerly slab a): %f\n", *s_c);
+	printf("available slabs: %d\n", count_available_slabs(&frame));
+
 
 	frame_free(&frame);
 }


### PR DESCRIPTION
Finished a basic slab allocator, which mallocs out a large chunk of memory comprised of many fixed sized "slabs." These slabs can have memory allocated on them without extra sys calls from malloc. The memory can also be made available to the chunk of slabs without a system call. This is useful for when you know you'll need many allocations of data of the same size, but also need to avoid the performance hit of using a bunch of mallocs everywhere.

For now, this version has a few drawbacks. Each slab's minimum possible size is equal to the size of a pointer. This, for example, means that if you want a slab allocator for floats and you are working with 8 byte pointers, there are 4 bytes of unused data in each slab. I have a way to potentially work around this, but I'll wait on implementing it

The other problem is that a few of the functions are rather unsafe, if you aren't careful about which pointers you are passing into certain functions. I have a workaround for this too, which is pretty simple, and which I'll make a seperate version of the allocator for.